### PR TITLE
Add .editorconfig to help different editor's consistently format files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 80
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
* use unix-style line delimiters
* utf-8 charset
* trim whitespace (except on markdown files)
* prefer spaces to tab (conventional in Ruby.)

Signed-off-by: James Phillips <jamesdphillips@gmail.com>