### PR TITLE
Remove Sparkline and Downloads Count

### DIFF
--- a/app/views/extensions/_download.html.erb
+++ b/app/views/extensions/_download.html.erb
@@ -1,10 +1,3 @@
-<h4 class="extension_show_sidebar_downloads">
-  <i class="fa fa-download"></i> 
-  <span itemprop="interactionCount"><%= number_with_delimiter(version.try(:download_count) || 0) %></span> 
-  <span>Downloads of Version <%= version.try(:version) %></span>
-  <small><%= number_with_delimiter(extension.download_count) %> Total Downloads</small>
-</h4>
-
 <div id="download_asset_or_definition" class="reveal-modal small" data-reveal>
   <h1>Download</h1>
   <a class="close-reveal-modal close-reveal-modal-x">&#215;</a>

--- a/app/views/extensions/_main_header.html.erb
+++ b/app/views/extensions/_main_header.html.erb
@@ -120,20 +120,6 @@
 
   <p class="description" itemprop="description"><%= extension.description %></p>
 
-  
-  <div class="row">
-    <%- if @downloads.present? %>
-      <div class="small-4 columns ">
-        <span class='downloads-commits'>Downloads in last month</span>
-        <div class="sparkline"><%= @downloads.join(",") %></div>
-      </div>
-    <% end %>
-    <%- if is_commitable?(@extension) %>
-      <div class="small-4 column end">
-        <span class='downloads-commits'>Commits in last year</span>
-        <div class="sparkline"><%= @commits.join(",") %></div>
-      </div>
-    <% end %>
   </div>
 
 </div>

--- a/app/views/extensions/_main_header.html.erb
+++ b/app/views/extensions/_main_header.html.erb
@@ -120,6 +120,4 @@
 
   <p class="description" itemprop="description"><%= extension.description %></p>
 
-  </div>
-
 </div>


### PR DESCRIPTION
These two metrics were not wholly accurate in what we were trying to represent. In addition they were perhaps sending the wrong message. We've chosen to remove them.