### PR TITLE
Queue extract basic metadata job

### DIFF
--- a/app/workers/collect_extension_metadata_worker.rb
+++ b/app/workers/collect_extension_metadata_worker.rb
@@ -5,7 +5,7 @@ class CollectExtensionMetadataWorker < ApplicationWorker
     CompileExtensionStatus.call(
       extension: extension,
       worker: 'ExtractExtensionBasicMetadataWorker',
-      job_id: ExtractExtensionBasicMetadataWorker.new.perform(extension.id)
+      job_id: ExtractExtensionBasicMetadataWorker.perform_async(extension.id)
     )
     CompileExtensionStatus.call(
       extension: extension,


### PR DESCRIPTION
I can't see a reason why we wouldn't want to queue the job and running it synchronously causes the job status to get stuck indefinitely.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>