### PR TITLE
Remove "recompile enterprise" runbook

### DIFF
--- a/lib/runbooks/recompile_enterprise_tier.rb
+++ b/lib/runbooks/recompile_enterprise_tier.rb
@@ -1,6 +1,0 @@
-enterprise_tier = Tier.find_by(name: 'Enterprise')
-extensions = Array.wrap(enterprise_tier&.extensions)
-
-extensions.each do |extension|
-  CompileExtension.call(extension: extension)
-end


### PR DESCRIPTION
It's unclear to me why we would need to recompile all the "enterprise" tier assets each time we start a process (web, worker, console, etc.). Chesterton's fence, et al.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>