### PR TITLE
Normalize extension versions

### DIFF
--- a/app/controllers/api/v1/extension_versions_controller.rb
+++ b/app/controllers/api/v1/extension_versions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::ExtensionVersionsController < Api::V1Controller
   #
   def show
     @extension = Extension.with_name(params[:extension]).first!
-    @extension_version = @extension.get_version!(params[:version])
+    @extension_version = @extension.get_version!(SemverNormalizer.call(params[:version]))
   end
 
   #
@@ -20,7 +20,7 @@ class Api::V1::ExtensionVersionsController < Api::V1Controller
   #
   def download
     @extension = Extension.with_name(params[:extension]).first!
-    @extension_version = @extension.get_version!(params[:version])
+    @extension_version = @extension.get_version!(SemverNormalizer.call(params[:version]))
 
     ExtensionVersion.increment_counter(:api_download_count, @extension_version.id)
     Extension.increment_counter(:api_download_count, @extension.id)

--- a/app/controllers/api/v1/release_assets_controller.rb
+++ b/app/controllers/api/v1/release_assets_controller.rb
@@ -11,9 +11,9 @@ class Api::V1::ReleaseAssetsController < Api::V1Controller
   example "GET https://#{ENV['HOST']}/api/v1/assets/sensu/sensu-email-handler/0.2.0/release_asset_builds"
   def index
     extension = Extension.with_owner_and_lowercase_name(owner_name: params[:username], lowercase_name: params[:id])
-    @version = extension.extension_versions.find_by!(version: params[:version])
+    @version = extension.extension_versions.find_by!(version: SemverNormalizer.call(params[:version]))
   end
-  
+
   api! <<~EOD
     Retrieve #{I18n.t('indefinite_articles.extension')} #{I18n.t('nouns.extension')}'s build-specific details, suitable for consumption by the sensu tool.
   EOD
@@ -23,10 +23,10 @@ class Api::V1::ReleaseAssetsController < Api::V1Controller
   param :platform, String, required: true, desc: "target platform"
   param :arch,     String, required: true, desc: "target architecture"
   example "GET https://#{ENV['HOST']}/api/v1/assets/demillir/sensu-asset-playground/0.1.1-20181030/linux/aarch64/release_asset"
-  
+
   def show
     extension = Extension.with_owner_and_lowercase_name(owner_name: params[:username], lowercase_name: params[:id])
-    version = extension.extension_versions.find_by!(version: params[:version])
+    version = extension.extension_versions.find_by!(version: SemverNormalizer.call(params[:version]))
     @release_asset = version.release_assets.find_by(platform: params[:platform], arch: params[:arch])
     raise ActiveRecord::RecordNotFound unless @release_asset
   end

--- a/app/controllers/extension_versions_controller.rb
+++ b/app/controllers/extension_versions_controller.rb
@@ -45,6 +45,8 @@ class ExtensionVersionsController < ApplicationController
     authorize! extension, :add_hosted_extension_version?
 
     @extension_version = extension.extension_versions.build(extension_version_params)
+    @extension_version.tag = @extension_version.version
+    @extension_version.version = SemverNormalizer.call(@extension_version.version)
 
     if @extension_version.save
       ExtensionNotifyWorker.perform_async(@extension_version.id)

--- a/app/controllers/release_assets_controller.rb
+++ b/app/controllers/release_assets_controller.rb
@@ -5,11 +5,11 @@ class ReleaseAssetsController < ApplicationController
   def download
 
     extension = Extension.with_owner_and_lowercase_name(owner_name: params[:username], lowercase_name: params[:extension_id])
-    version = extension.extension_versions.find_by!(version: params[:version])
+    version = extension.extension_versions.find_by!(version: SemverNormalizer.call(params[:version]))
     @release_asset = version.release_assets.find_by(platform: params[:platform], arch: params[:arch])
 
     if !@release_asset || !@release_asset.viable?
-      raise ActiveRecord::RecordNotFound 
+      raise ActiveRecord::RecordNotFound
     end
 
     raise ActiveRecord::RecordNotFound if extension.hosted? && !params[:acknowledge]
@@ -44,7 +44,7 @@ class ReleaseAssetsController < ApplicationController
 
   def send_file_content(filename_method)
     extension = Extension.with_owner_and_lowercase_name(owner_name: params[:username], lowercase_name: params[:extension_id])
-    version   = extension.extension_versions.find_by!(version: params[:version])
+    version   = extension.extension_versions.find_by!(version: SemverNormalizer.call(params[:version]))
     raise ActiveRecord::RecordNotFound unless version.source_file.attached?
 
     release_asset = version.release_assets.find_by(platform: params[:platform], arch: params[:arch])

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -28,7 +28,7 @@ class Extension < ApplicationRecord
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings
   has_many :forks, class_name: 'Extension', foreign_key: :parent_id
-  has_many :extension_collections, dependent: :destroy 
+  has_many :extension_collections, dependent: :destroy
   has_many :collections, through: :extension_collections
 
   # HACK: +Extension+ objects don't really have a source_file attachment or version attribute.
@@ -158,7 +158,7 @@ class Extension < ApplicationRecord
     message: ': upload file must be a compressed archive type'
   }, if: ->(record) { record.tmp_source_file&.attachment }
 
-  class << self 
+  class << self
 
     def with_owner_and_lowercase_name(owner_name:, lowercase_name:)
       Extension.find_by!(owner_name: owner_name, lowercase_name: lowercase_name)
@@ -200,9 +200,9 @@ class Extension < ApplicationRecord
           REGEXP_REPLACE(
             REGEXP_REPLACE(
               REGEXP_REPLACE(
-                extension_versions.version, 
+                extension_versions.version,
                 E'[-](.*)', ''
-              ), 
+              ),
              E'[\+](.*)', ''
             ),
             E'V|v|master', ''
@@ -340,7 +340,7 @@ class Extension < ApplicationRecord
     if version == 'latest'
       latest_extension_version
     else
-      extension_versions.find_by!(version: version)
+      extension_versions.find_by!(version: SemverNormalizer.call(version))
     end
   end
 
@@ -380,7 +380,8 @@ class Extension < ApplicationRecord
         extension: self,
         description: metadata.description,
         license: metadata.license,
-        version: metadata.version,
+        tag: metadata.version,
+        version: SemverNormalizer.call(metadata.version),
         tarball: tarball,
         readme: readme.contents,
         readme_extension: readme.extension,

--- a/app/workers/extract_extension_version_worker.rb
+++ b/app/workers/extract_extension_version_worker.rb
@@ -9,7 +9,8 @@ class ExtractExtensionVersionWorker < ApplicationWorker
 
     readme_body, readme_ext = fetch_readme
 
-    version = @extension.extension_versions.first_or_create(version: tag)
+    normalized_version = SemverNormalizer.call(extension_version.version)
+    version = @extension.extension_versions.first_or_create(version: normalized_version, tag: tag)
 
     version.update_attributes(
       readme: readme_body,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,9 +92,11 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  redis_url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379")
+
   # cache store in production.
   config.cache_store = :redis_cache_store, {
-    url: "#{ENV['REDIS_URL']}/0", 
+    url: "#{redis_url}/0",
     network_timeout: 1,
     namespace: "cache",
   }

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,5 @@
+redis_url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379")
 
-REDIS_POOL = ConnectionPool.new(size: 10) { Redis.new(url: "#{ENV['REDIS_URL']}/0", network_timeout: 5) }
+REDIS_POOL = ConnectionPool.new(size: 10) { Redis.new(url: "#{redis_url}/0", network_timeout: 5) }
 
-Redis.current = Redis.new(url: "#{ENV['REDIS_URL']}/1", network_timeout: 5)
+Redis.current = Redis.new(url: "#{redis_url}/1", network_timeout: 5)

--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -2,8 +2,10 @@ def Object.const_missing(const)
   if const == :ROLLOUT
     require 'redis'
 
+    redis_url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379")
+
     #redis_connect = {}.tap { |h| h[:host] = ENV["REDIS_HOST"] if ENV["REDIS_HOST"] }
-    redis = Redis.new(:url => "#{ENV['REDIS_URL']}/1")
+    redis = Redis.new(:url => "#{redis_url}/1")
 
     Object.const_set('ROLLOUT', Rollout.new(redis))
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,8 @@ Sidekiq.default_worker_options = {
 
 Sidekiq.configure_server do |config|
   config.redis = REDIS_POOL
-  Redis.current = Redis.new(url: "#{ENV['REDIS_URL']}/1", network_timeout: 5)
+  redis_url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379")
+  Redis.current = Redis.new(url: "#{redis_url}/1", network_timeout: 5)
   Sidekiq::Status.configure_server_middleware config, expiration: 7.days
   Sidekiq::Status.configure_client_middleware config, expiration: 7.days
 end

--- a/db/migrate/20200213205500_add_tag_to_extension_version.rb
+++ b/db/migrate/20200213205500_add_tag_to_extension_version.rb
@@ -1,0 +1,20 @@
+class AddTagToExtensionVersion < ActiveRecord::Migration[5.2]
+  def up
+    add_column :extension_versions, :tag, :string
+
+    ExtensionVersion.all.each do |extension_version|
+      extension_version.tag = extension_version.version
+      extension_version.version = SemverNormalizer.call(extension_version.version)
+      extension_version.save
+    end
+  end
+
+  def down
+    ExtensionVersion.all.each do |extension_version|
+      extension_version.version = extension_version.tag
+      extension_version.save
+    end
+
+    remove_column :extension_versions, :tag
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_13_232729) do
+ActiveRecord::Schema.define(version: 2020_02_13_205500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -328,6 +328,7 @@ ActiveRecord::Schema.define(version: 2020_01_13_232729) do
     t.jsonb "config", default: {}
     t.string "compilation_error"
     t.text "annotations"
+    t.string "tag"
     t.index ["config"], name: "index_extension_versions_on_config", using: :gin
     t.index ["legacy_id"], name: "index_extension_versions_on_legacy_id", unique: true
     t.index ["version", "extension_id"], name: "index_extension_versions_on_version_and_extension_id", unique: true


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Adds a new field to `ExtensionVersion` called `tag` which stores the GitHub tag. The migration will store the current value of `version` in the new `tag` field and then semver normalize the `version` field.

The resource id for `ExtensionsController` and related API controllers is now semver normalized which enables users to visit URLs with or without a prefixed `v` on version ids.