### PR TITLE
Improve signed_in? verification

### DIFF
--- a/app/authorizers/extension_authorizer.rb
+++ b/app/authorizers/extension_authorizer.rb
@@ -117,7 +117,7 @@ class ExtensionAuthorizer < Authorizer::Base
 
   def download_hosted_extension_version_source?
     owner_or_admin?
-  end 
+  end
 
   def change_tier?
     admin?
@@ -134,7 +134,7 @@ class ExtensionAuthorizer < Authorizer::Base
   def edit_extension_config_overrides?
     owner_or_admin?
   end
-  
+
   def report?
     signed_in?
   end
@@ -142,7 +142,7 @@ class ExtensionAuthorizer < Authorizer::Base
   private
 
   def signed_in?
-    user.persisted?
+    user&.persisted? || false
   end
 
   def admin?

--- a/app/authorizers/extension_authorizer.rb
+++ b/app/authorizers/extension_authorizer.rb
@@ -142,7 +142,7 @@ class ExtensionAuthorizer < Authorizer::Base
   private
 
   def signed_in?
-    user.present?
+    user.persisted?
   end
 
   def admin?

--- a/spec/authorizers/extension_authorizer_spec.rb
+++ b/spec/authorizers/extension_authorizer_spec.rb
@@ -14,4 +14,21 @@ describe ExtensionAuthorizer do
       it {expect(subject.make_hosted_extension?).to be_falsey}
     end
   end
+
+  describe '#report?' do
+    context 'authenticated user' do
+      let (:user) { build_stubbed :user }
+      it {expect(subject.report?).to be(true) }
+    end
+
+    context 'user present; record not persisted' do
+      let (:user) { User.new }
+      it {expect(subject.report?).to be(false) }
+    end
+
+    context 'no user present' do
+      let (:user) { nil }
+      it {expect(subject.report?).to be(false) }
+    end
+  end
 end


### PR DESCRIPTION
We currently determine if the user is `signed_in?` by checking that the `ExtensionAuthorizer` has been configured with an account. This however, is problematic because the constructor ensures that the `@user` instance variable _always_ [has a value](https://github.com/sensu/bonsai/blob/master/app/lib/authorizer/base.rb#L16).

Ultimately this gap led to a lot of spam emails to our administrator accounts.

To fill this gap, I've updated the authorizer to check if the user is not just present but has been persisted. 

--- 

In terms of determining whether a user is able to report an asset we may want to do more than check that the user is "signed in". For instance, we may want to check if they've linked their Github account or otherwise has confirmed their email. And / or include a captcha.