### PR TITLE
Update the Deprecate modal for the latest Select2 version

### DIFF
--- a/app/assets/javascripts/extensionDeprecate.js
+++ b/app/assets/javascripts/extensionDeprecate.js
@@ -1,35 +1,24 @@
-$(document).on('opened', '[data-reveal]', function () {
+$(document).ready(function() {
   var settings =  {
     placeholder: 'Search for an asset',
     minimumInputLength: 3,
     width: '100%',
     ajax: {
-      url: function () {
-        return $(this).data('url');
-      },
+      url: $('.extension-deprecate').data('url'),
       dataType: 'json',
-      quietMillis: 200,
-      data: function (term, page) {
-        return { q: term };
-      },
-      results: function (data, page) {
-        return { results: data.items };
-      },
-    },
-    id: function(object) {
-      return [object.extension_owner, object.extension_name];
-    },
-    formatSelection: function(object, container) {
-      return [object.extension_owner, object.extension_name].join('/');
-    },
-    formatResult: function(object, container) {
-      return [object.extension_owner, object.extension_name].join('/');
+      processResults: function (data, page) {
+        let results = data.items.map(o => {
+          let id_vals = [o.extension_owner, o.extension_name];
+          return {id: id_vals.join(','), text: id_vals.join('/')}
+        })
+        return { results: results };
+      }
     }
   }
 
   $('.extension-deprecate').select2(settings);
 
-  $('.extension-deprecate').on("select2-selecting", function(e) {
+  $('.extension-deprecate').on("select2:select", function(e) {
     $('.submit-deprecation').prop('disabled', false);
   });
 });

--- a/app/assets/javascripts/extensionDeprecate.js
+++ b/app/assets/javascripts/extensionDeprecate.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
   var settings =  {
-    placeholder: 'Search for an asset',
+    placeholder: 'Search for replacement asset',
     minimumInputLength: 3,
     width: '100%',
     ajax: {

--- a/app/views/extensions/_manage_extension.html.erb
+++ b/app/views/extensions/_manage_extension.html.erb
@@ -85,7 +85,7 @@
       <%= form_for extension, url: deprecate_extension_path(extension, username: extension.owner_name), method: :put do |f| %>
         <div class="row collapse">
           <div class="small-9 columns">
-            <%= f.hidden_field :replacement, class: 'extension-deprecate', 'data-url' => deprecate_search_extension_path(extension, username: extension.owner_name) %>
+            <%= f.select :replacement, [], {}, class: 'extension-deprecate', 'data-url' => deprecate_search_extension_path(extension, username: extension.owner_name) %>
           </div>
           <div class="small-3 columns">
             <%= f.submit 'Deprecate', class: 'button radius postfix submit-deprecation', disabled: true %>

--- a/app/views/extensions/_manage_extension.html.erb
+++ b/app/views/extensions/_manage_extension.html.erb
@@ -78,7 +78,12 @@
     <div id="deprecate" class="reveal-modal small" data-reveal>
       <h1>Deprecate <%= t('nouns.extension').titleize %></h1>
 
-      <p>You can deprecate your <%= t('nouns.extension') %> if you are no longer maintaining it. You must select a replacement <%= t('nouns.extension') %> in order to deprecate your <%= t('nouns.extension') %>.</p>
+      <p>
+        You can deprecate this <%= t('nouns.extension') %>
+        if you are no longer maintaining it.
+        You must select a replacement <%= t('nouns.extension') %>
+        in order to deprecate this <%= t('nouns.extension') %>.
+      </p>
 
       <a class="close-reveal-modal">&#215;</a>
 


### PR DESCRIPTION
This branch fixes a bug that crept in in 2019, when we upgraded the Select2 JS library from version 3.x to version 4.

Closes #317 