### PR TITLE
Add an auth scope to allow team members to be collaborators

### DIFF
--- a/app/lib/bonsai_asset_index/authentication.rb
+++ b/app/lib/bonsai_asset_index/authentication.rb
@@ -1,6 +1,6 @@
 module BonsaiAssetIndex
   module Authentication
-    AUTH_SCOPE = "public_repo,user:email,write:repo_hook,push"
+    AUTH_SCOPE                 = "public_repo,read:org,user:email,write:repo_hook,push"
 
     #
     # Include the following methods as helper methods.


### PR DESCRIPTION
[Collaborator check when trying to add new assets doesn't pick up team roles](https://github.com/sensu/bonsai/issues/345)